### PR TITLE
Actually bail if db not present. Fixes #4.

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -32,7 +32,7 @@ function canonicalize(email) {
 // the 'todo/get' api gets the current version of the todo list
 // from the server
 app.get('/mail/:user', function(req, res) {
-  if (!db) res.json([]);
+  if (!db) return res.json([]);
 
   req.params.user = canonicalize(req.params.user);
 
@@ -53,7 +53,7 @@ app.get('/mail/:user', function(req, res) {
 });
 
 app.delete('/mail/:user', function(req, res) {
-  if (!db) res.send(200);
+  if (!db) return res.send(200);
 
   req.params.user = canonicalize(req.params.user);
 


### PR DESCRIPTION
@jedp or @seanmonstar, mind having a look?

Hmm. arguably if the DB is gone we should return a 500 every time?

Ah well. This preserves current behavior, minus one bug I found (#4) and another I didn't (when you try to DELETE a user programmatically and the DB is gone, same badness).

res.json/res.send means res is done, but the function continues, does db.foo() where db is null, and, f7u12.
