### PR TITLE
expire data after configurable interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ user, and you can also delete outstanding messages via the API.
 
 This lets you test services that deliver email.
 
+By default, emails are deleted after one day.  You can change this
+by modifying the `expireAfter` parameter in `config.js`.  Set it to
+`0` for no auto-deletion, in which case you will want to keep an
+eye on your redis database size.
+
 ## security?
 
 All mail sent to restmail email addresses is completely public.  anyone

--- a/config.js
+++ b/config.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+  // Interval in seconds after which to automatically delete mail.
+  // Set to 0 for no auto-delete, and keep an eye on the size of
+  // your redis db.
+  expireAfter: 60 * 60 * 24
+};

--- a/emailserver.js
+++ b/emailserver.js
@@ -1,6 +1,7 @@
 var smtp = require('smtp-protocol'),
    redis = require("redis"),
-   MailParser = require("mailparser").MailParser;
+   MailParser = require("mailparser").MailParser,
+   config = require("./config");
 
 // create a connection to the redis datastore
 var db = redis.createClient();
@@ -33,6 +34,10 @@ var server = smtp.createServer('restmail.net', function (req) {
       var user = req.to;
       db.rpush(user, JSON.stringify(mail), function(err) {
         if (err) return loggit(err);
+
+        if (config.expireAfter) {
+          db.expire(user, config.expireAfter);
+        }
 
         db.llen(user, function(err, replies) {
           if (err) return loggit(err);


### PR DESCRIPTION
Addresses Issue #8.

In its present form, restmail accumulates emails indefinitely.  This can lead to the redis db overflowing memory.

E.g., http://irclog.gr/#show/irc.mozilla.org/identity/293731

This PR adds auto-expiration of all data after a configurable interval.
