### PR TITLE
Bump hiredis version for node 0.10 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "mailparser": "0.2.26"
   },
   "optionalDependencies": {
-    "hiredis": "0.1.14"
+    "hiredis": "0.1.15"
   },
   "devDependencies": {
     "awsbox": "0.2.16",


### PR DESCRIPTION
For details, see https://github.com/pietern/hiredis-node/issues/24

This was preventing me from testing locally.
