### PR TITLE
Pretty-print the JSON output.

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -47,7 +47,8 @@ app.get('/mail/:user', function(req, res) {
           arr.push(JSON.parse(r));
         } catch(e) { }
       });
-      res.json(arr);
+      res.setHeader("Content-Type", "application/json");
+      res.send(JSON.stringify(arr, undefined, 2));
     }
   });
 });


### PR DESCRIPTION
This makes it much nicer when hitting the restmail.net REST API by
hand, in a browser.
