### PR TITLE
Add support for multiple SMTP transactions per connection.

### DIFF
--- a/emailserver.js
+++ b/emailserver.js
@@ -66,6 +66,18 @@ var server = smtp.createServer(HOSTNAME, function (req) {
     ack.accept(354, 'OK');
     users = []
   });
+
+  req.on('rset', function() {
+    users = []
+  })
+
+  req.on('command', function(cmd, r) {
+    if (cmd.name === 'noop') {
+      r.preventDefault()
+      r.write(250)
+      r.next()
+    }
+  })
 });
 
 // handle starting from the command line or the test harness

--- a/emailserver.js
+++ b/emailserver.js
@@ -24,6 +24,32 @@ function logError(err) {
   log("ERROR (oh noes!): " + err);
 }
 
+function mailSummary(mail) {
+  const deliveryTime =
+    new Date(mail.receivedAt).getTime() - new Date(mail.date).getTime();
+
+  const summary = {
+    subject: mail.subject,
+    from: mail.from,
+    to: mail.to,
+    date: mail.date,
+    receivedAt: mail.receivedAt,
+    deliveryTime: deliveryTime
+  };
+
+  if (mail.headers) {
+    summary.headers = {
+      subject: mail.headers.subject,
+      from: mail.headers.from,
+      to: mail.headers.to,
+      cc: mail.headers.cc,
+      date: mail.headers.date
+    };
+  }
+
+  return JSON.stringify(summary);
+}
+
 var server = smtp.createServer(HOSTNAME, function (req) {
   log('Handling SMTP request');
 
@@ -43,7 +69,7 @@ var server = smtp.createServer(HOSTNAME, function (req) {
 
     mailparser.on('end', (function(users, mail) {
       mail.receivedAt = new Date().toISOString();
-      log('Received message for', users, mail);
+      log('Received message for', users, mailSummary(mail));
       users.forEach(function(user) {
         db.rpush(user, JSON.stringify(mail), function(err) {
           if (err) return logError(err);

--- a/tests.js
+++ b/tests.js
@@ -86,7 +86,6 @@ describe('sending email', function() {
 
       s.end("helo\nmail from: <lloyd@localhost>\nrcpt to: <me@localhost>\ndata\nfrom: lloyd <lloyd@localhost>\nto: me <me@localhost>\n\nhi\n.\nquit\n");
     });
-    setTimeout(function() { console.log('waited'); });
   });
 });
 
@@ -134,7 +133,6 @@ describe('sending to multiple recipients', function() {
 
       s.end("helo\nmail from: <lloyd@localhost>\nrcpt to: <me@localhost>\nrcpt to: <you@localhost>\ndata\nfrom: lloyd <lloyd@localhost>\nto: me <me@localhost>\ncc: you <you@localhost>\n\nhi\n.\nquit\n");
     });
-    setTimeout(function() { console.log('waited'); });
   });
 });
 
@@ -212,7 +210,6 @@ describe('sending two mails on the same TCP connection', function() {
 
       s.end("helo\nmail from: <lloyd@localhost>\nrcpt to: <me@localhost>\ndata\nfrom: lloyd <lloyd@localhost>\nto: me <me@localhost>\n\nhello\n.\nmail from: <me@localhost>\nrcpt to: <you@localhost>\ndata\nfrom: me <me@localhost>\nto: you <you@localhost>\n\nworld\n.\nquit\n");
     });
-    setTimeout(function() { console.log('waited'); });
   });
 });
 
@@ -270,6 +267,73 @@ describe('web apis', function() {
   });
 });
 
+describe('the SMTP RSET and NOOP commands', function() {
+  it('should be supported', function(done) {
+    var s = net.connect(emailPort, function(err) {
+      should.not.exist(err);
+
+      var response = "";
+      s.on('data', function(chunk) { response += chunk; });
+
+      s.on('end', function() {
+        var lines = response.split('\r\n')
+        lines[3].should.equal('250 OK');
+        lines[4].should.equal('250');
+        lines[11].should.equal('221 Bye!');
+        s.destroy();
+        done();
+      });
+
+      s.end("helo\nmail from: <lloyd@localhost>\nrcpt to: <me@localhost>\nrset\nmail from: <me@localhost>\nnoop\nrcpt to: <you@localhost>\ndata\nfrom: me <me@localhost>\nto: you <you@localhost>\n\njust4you\n.\nnoop\nquit\n");
+    });
+  });
+});
+
+describe('web apis', function() {
+  it('should show that mail was not delivered after a reset', function(done) {
+    http.request({
+      host: '127.0.0.1',
+      port: webPort,
+      path: '/mail/me@localhost',
+      method: 'GET'
+    }, function(res) {
+      (res.statusCode).should.equal(200);
+      var data = "";
+      res.on('data', function (chunk) { data += chunk; });
+      res.on('end', function () {
+        data = JSON.parse(data);
+        data.length.should.equal(3);
+        done();
+      });
+    }).end();
+  });
+
+  it('should return new mail delivered after a reset', function(done) {
+    http.request({
+      host: '127.0.0.1',
+      port: webPort,
+      path: '/mail/you@localhost',
+      method: 'GET'
+    }, function(res) {
+      (res.statusCode).should.equal(200);
+      var data = "";
+      res.on('data', function (chunk) { data += chunk; });
+      res.on('end', function () {
+        data = JSON.parse(data);
+        data.length.should.equal(3);
+        data = data[2];
+        data.text.should.equal('just4you\n');
+        data.receivedAt.should.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+        data.from[0].address.should.equal('me@localhost');
+        data.from[0].name.should.equal('me');
+        data.to[0].address.should.equal('you@localhost');
+        data.to[0].name.should.equal('you');
+        Object.keys(data.headers).length.should.equal(2);
+        done();
+      });
+    }).end();
+  });
+});
 
 describe('clearing email', function() {
   it('should work', function(done) {

--- a/tests.js
+++ b/tests.js
@@ -196,6 +196,81 @@ describe('web apis', function() {
   });
 });
 
+describe('sending two mails on the same TCP connection', function() {
+  it('should work', function(done) {
+    var s = net.connect(emailPort, function(err) {
+      should.not.exist(err);
+
+      var response = "";
+      s.on('data', function(chunk) { response += chunk; });
+
+      s.on('end', function() {
+        response.split('\r\n')[10].should.equal('221 Bye!');
+        s.destroy();
+        done();
+      });
+
+      s.end("helo\nmail from: <lloyd@localhost>\nrcpt to: <me@localhost>\ndata\nfrom: lloyd <lloyd@localhost>\nto: me <me@localhost>\n\nhello\n.\nmail from: <me@localhost>\nrcpt to: <you@localhost>\ndata\nfrom: me <me@localhost>\nto: you <you@localhost>\n\nworld\n.\nquit\n");
+    });
+    setTimeout(function() { console.log('waited'); });
+  });
+});
+
+describe('web apis', function() {
+  it('should return new mail for the address from the first delivery', function(done) {
+    http.request({
+      host: '127.0.0.1',
+      port: webPort,
+      path: '/mail/me@localhost',
+      method: 'GET'
+    }, function(res) {
+      (res.statusCode).should.equal(200);
+      var data = "";
+      res.on('data', function (chunk) { data += chunk; });
+      res.on('end', function () {
+        data = JSON.parse(data);
+        data.length.should.equal(3);
+        data = data[2];
+        data.text.should.equal('hello\n');
+        data.receivedAt.should.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+        data.from[0].address.should.equal('lloyd@localhost');
+        data.from[0].name.should.equal('lloyd');
+        data.to[0].address.should.equal('me@localhost');
+        data.to[0].name.should.equal('me');
+        Object.keys(data.headers).length.should.equal(2);
+        done();
+      });
+    }).end();
+  });
+
+  it('should return new mail for the address from the second delivery', function(done) {
+    http.request({
+      host: '127.0.0.1',
+      port: webPort,
+      path: '/mail/you@localhost',
+      method: 'GET'
+    }, function(res) {
+      (res.statusCode).should.equal(200);
+      var data = "";
+      res.on('data', function (chunk) { data += chunk; });
+      res.on('end', function () {
+        data = JSON.parse(data);
+        data.length.should.equal(2);
+        data = data[1];
+        data.text.should.equal('world\n');
+        data.receivedAt.should.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+        data.from[0].address.should.equal('me@localhost');
+        data.from[0].name.should.equal('me');
+        data.to[0].address.should.equal('you@localhost');
+        data.to[0].name.should.equal('you');
+        Object.keys(data.headers).length.should.equal(2);
+        done();
+      });
+    }).end();
+  });
+});
+
+
 describe('clearing email', function() {
   it('should work', function(done) {
     http.request({


### PR DESCRIPTION
This hopefully fixes #21 by adding support for more SMTP stuff that might be seen in the wild, including:

* Multiple transactions done on a single connection
* NOOP commands
* RSET commands (which I haven't seen i the wild, but seemed pretty easy and in line with the rest of the changes)

@vladikoff @jrgm r?