### PR TITLE
Add some restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ fields stripped out):
       }
     ]
 
-## restmail on your domain
+## restmail on your domain (deprecated; the public restmail.net is now resricted).
 
 You can use restmail from custom domains:  Just set restmail as your mail exchanger:
 

--- a/config.js
+++ b/config.js
@@ -1,7 +1,18 @@
 module.exports = {
-
   // Interval in seconds after which to automatically delete mail.
   // Set to 0 for no auto-delete, and keep an eye on the size of
   // your redis db.
-  expireAfter: 60 * 60 * 24
+  expireAfter: 60 * 60 * 24,
+
+  // Maximum number of RCPT TO on one connection dialogue. If there are more
+  // than this limit, an error will returned and the connection terminated.
+  maximumRcptTo: 5,
+
+  // Domain whitelist. RCPT TO addresses must match one of the domains on this
+  // list. (Strict matching, no subdomains).
+  rcptToDomainWhitelist: [
+    'restmail.net',
+    'restmail.com',
+    'restmail.dev.lcip.org'
+  ]
 };

--- a/config.js
+++ b/config.js
@@ -1,18 +1,30 @@
+function rcptToDomainWhitelist() {
+  const defaults = [
+    'localhost',
+    'restmail.net',
+    'restmail.com',
+    'example.com'
+  ];
+
+  if (process.env.RESTMAIL_RCPT_TO_DOMAIN_WHITELIST) {
+    return process.env.RESTMAIL_RCPT_TO_DOMAIN_WHITELIST.split(',');
+  }
+
+  return defaults;
+}
+
+
 module.exports = {
   // Interval in seconds after which to automatically delete mail.
   // Set to 0 for no auto-delete, and keep an eye on the size of
   // your redis db.
-  expireAfter: 60 * 60 * 24,
+  expireAfter: process.env.RESTMAIL_EXPIRE_AFTER || 60 * 60 * 24,
 
   // Maximum number of RCPT TO on one connection dialogue. If there are more
   // than this limit, an error will returned and the connection terminated.
-  maximumRcptTo: 5,
+  maximumRcptTo: process.env.RESTMAIL_MAXIMUM_RCPT_TO || 5,
 
   // Domain whitelist. RCPT TO addresses must match one of the domains on this
   // list. (Strict matching, no subdomains).
-  rcptToDomainWhitelist: [
-    'restmail.net',
-    'restmail.com',
-    'restmail.dev.lcip.org'
-  ]
+  rcptToDomainWhitelist: rcptToDomainWhitelist()
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint *.js tests/*.js loadtest/*.js",
     "loadtest": "node loadtest/index.js -d 3000",
     "start": "node webserver.js",
-    "test": "npm run lint && mocha --exit --globals msg -R spec tests/*.js && npm run loadtest"
+    "test": "npm run lint && npm run tests && npm run loadtest",
+    "tests": "mocha --exit --globals msg -R spec tests/*.js"
   }
 }


### PR DESCRIPTION
r? - @vladikoff, @jbuck 

This puts in restrictions:

 1) more than 5 'rcpt to:',
 2) using an email with domain not in {localhost,restmail.com,restmail.net,example.com}

will result in rejection of the request.

If i need to adjust these limits, they can be set via the environment.