### PR TITLE
Remove `request` from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "eslint-plugin-fxa": "git://github.com/mozilla/eslint-plugin-fxa.git#41504c9dd30e8b52900c15b524946aa0428aef95",
     "eslint-plugin-sorting": "git://github.com/shane-tomlinson/eslint-plugin-sorting.git#bcacb99d",
     "mocha": "10.4.0",
-    "request": "2.88.2",
     "should": "13.2.3"
   },
   "engines": {


### PR DESCRIPTION
So, `requests` was EOL'd in 2019 and is holding us back on dependency upgrades.  But..... I don't actually see us using it anywhere?  I looked in the code.  I removed it and ran the tests.   ???

